### PR TITLE
Fix critical bugs across LinearAlgebra, Graphs, Geometry, and Functio…

### DIFF
--- a/include/Graphs/BaseGraph.h
+++ b/include/Graphs/BaseGraph.h
@@ -10,9 +10,9 @@ namespace SharedMath::Graphs
 {
     template<typename T>
     struct GraphNode{
-        GraphNode(T Data) : 
-            data(Data), 
-            childs(std::vector<GraphNode*>(nullptr)),
+        GraphNode(T Data) :
+            data(Data),
+            childs(std::vector<GraphNode*>()),
             parent(nullptr),
             isRoot(false)
             {}
@@ -21,7 +21,7 @@ namespace SharedMath::Graphs
         std::vector<GraphNode*> childs;
         T data;
         GraphNode* parent {nullptr};
-        bool isRoot {nullptr};
+        bool isRoot {false};
     };
 
     template<typename T>
@@ -30,7 +30,7 @@ namespace SharedMath::Graphs
         BaseGraph(T rootData);
         virtual ~BaseGraph();
 
-        GraphNode<T>* getRoot() const {return root};
+        GraphNode<T>* getRoot() const {return root;}
         GraphNode<T>* findNode(T data) const;
 
         void clear();
@@ -46,10 +46,7 @@ namespace SharedMath::Graphs
 
     template<typename T>
     inline BaseGraph<T>::BaseGraph(T rootData){
-        this->root = new T();
-        root->childs = std::vector<GraphNode<T>*>(nullptr);
-        root->data = rootData;
-        root->parent = nullptr;
+        this->root = new GraphNode<T>(rootData);
         root->isRoot = true;
     }
 
@@ -108,8 +105,8 @@ namespace SharedMath::Graphs
                 if(node->data == data)return node;
 
                 auto childNodes = node->childs;
-                for(const auto* childNode : childNodes){
-                    if(!childNode)
+                for(auto* childNode : childNodes){
+                    if(childNode)
                         nodesQueue.push(childNode);
                 }
             }

--- a/include/LinearAlgebra/DefaultScalarMatrixOperations.h
+++ b/include/LinearAlgebra/DefaultScalarMatrixOperations.h
@@ -18,10 +18,7 @@ namespace SharedMath::LinearAlgebra
                 lu.MakeDecomposition();
                 return lu.Determinant();
             }catch(const std::exception& ex){
-                return lu.Determinant();
                 throw std::runtime_error(std::string("Could not calculate determinant: ") + std::string(ex.what()));
-            }catch(...){
-                throw;
             }
         }
         bool isSupported(const AbstractMatrix& A) const override{

--- a/include/LinearAlgebra/Matrix.h
+++ b/include/LinearAlgebra/Matrix.h
@@ -83,34 +83,31 @@ namespace SharedMath
             }
 
             double* rowPtr(size_t row){
-                if(row > Rows){
+                if(row >= Rows){
                     throw std::out_of_range("Row index is out of range");
                 }
                 return &(data[row][0]);
             }
 
             const double* rowPtr(size_t row) const{
-                if(row > Rows){
+                if(row >= Rows){
                     throw std::out_of_range("Row index is out of range");
                 }
                 return &(data[row][0]);
             }
 
             double get(size_t row, size_t col) const override{
-                if( (row < 0 || col < 0) || 
-                    (row >= Rows || col >= Cols))throw std::runtime_error("Invalid index of element in matrix");
+                if(row >= Rows || col >= Cols)throw std::runtime_error("Invalid index of element in matrix");
                 return data[row][col];
             }
 
             double& get(size_t row, size_t col) override{
-                if( (row < 0 || col < 0) || 
-                    (row >= Rows || col >= Cols))throw std::runtime_error("Invalid index of element in matrix");
+                if(row >= Rows || col >= Cols)throw std::runtime_error("Invalid index of element in matrix");
                 return data[row][col];
             }
 
             void set(size_t row, size_t col, double val) override{
-                if( (row < 0 || col < 0) || 
-                    (row >= Rows || col >= Cols))throw std::runtime_error("Invalid index of element in matrix");
+                if(row >= Rows || col >= Cols)throw std::runtime_error("Invalid index of element in matrix");
                 data[row][col] = val;
             }
 

--- a/include/LinearAlgebra/VectorN.h
+++ b/include/LinearAlgebra/VectorN.h
@@ -72,7 +72,7 @@ namespace SharedMath
             }
 
             Vector normalized() const{
-                double length = norm;
+                double length = norm();
                 if(length < Epsilon){
                     throw std::runtime_error("Cannot normalize zero vector");
                 }

--- a/include/geometry/Planimetry/Polygon.h
+++ b/include/geometry/Planimetry/Polygon.h
@@ -74,8 +74,8 @@ namespace SharedMath
             }
 
             static double crossProduct(const Point2D& first, const Point2D& second, const Point2D& third){
-                return (second.x() - first.x() * (third.y() - first.y())-
-                        second.y() - first.y() * (third.x() - first.x()));
+                return ((second.x() - first.x()) * (third.y() - first.y()) -
+                        (second.y() - first.y()) * (third.x() - first.x()));
             }
             
         };

--- a/src/functions/GammaFunc.cpp
+++ b/src/functions/GammaFunc.cpp
@@ -4,7 +4,7 @@
 using namespace SharedMath::Functions;
 
 double GammaFunction::value(double x){
-    if(abs(x - 0.0) == Epsilon)return 1;
+    if(std::abs(x) < Epsilon)return 1.0;
     auto result = value({x, 0.0});
     return std::real(result);
 }


### PR DESCRIPTION
…ns modules

- VectorN: `norm` → `norm()` (missing call, caused compile error)
- BaseGraph: wrong allocation `new T()` → `new GraphNode<T>(rootData)`, invalid vector ctor, `bool isRoot {nullptr}` → `{false}`, missing semicolon in getRoot, inverted null-check in findNode that caused BFS to push only null pointers
- Polygon: missing parentheses in crossProduct formula produced wrong math
- DefaultScalarMatrixOperations: unreachable `throw` after `return` in catch block — exceptions were silently swallowed
- GammaFunc: `abs(x) == Epsilon` → `std::abs(x) < Epsilon` (float equality is always wrong)
- Matrix: removed dead `size_t < 0` checks and fixed off-by-one `row > Rows` → `row >= Rows`