### PR TITLE
Rework CMake to support shared and static library builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ build/
 CMakeFiles/
 *.a
 *.cmake
+# Allow cmake source modules in the cmake/ directory
+!cmake/*.cmake
 .vscode/
 examples/demo_example
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,32 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(PROJECT_TITLE SharedMath)
-
-MESSAGE("CMake version ${CMAKE_VERSION}")
-
-string(TOLOWER ${PROJECT_TITLE} PROJECT_NAME_LOWER)
-string(TOUPPER ${PROJECT_TITLE} PROJECT_NAME_UPPER)
-
 string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" is_top_level)
-message(STATUS "[INFO]: is_top_level ${is_top_level}")
 
 if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
     set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Debug postfix")
 endif()
 
-project(${PROJECT_TITLE}
+project(SharedMath
     VERSION 1.0.0
     DESCRIPTION "Math library for shared computations"
     LANGUAGES CXX)
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
-    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
-endif()
+string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
+string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version_utils.cmake)
-    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version_utils.cmake)
-    make_version_from_git()
-endif()
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
 
-option(${PROJECT_NAME}_BUILD_TESTS "Build ${PROJECT_NAME} tests as separate executable" ON)
-option(${PROJECT_NAME}_RUN_TESTS "Run ${PROJECT_NAME} tests" ON)
-option(${PROJECT_NAME}_INSTALL "Generate target for installing ${PROJECT_NAME}" ${is_top_level})
-option(${PROJECT_NAME}_SHARED_LIBS "Generate shared lib ${PROJECT_NAME}" OFF)
-option(${PROJECT_NAME}_BUILD_EXAMPLES "Build ${PROJECT_NAME} examples" ON)
+# --------------------------------------------------------------------------- #
+# Options
+# --------------------------------------------------------------------------- #
+option(${PROJECT_NAME}_BUILD_TESTS    "Build ${PROJECT_NAME} unit tests"       ON)
+option(${PROJECT_NAME}_INSTALL        "Generate install rules"                 ${is_top_level})
+option(${PROJECT_NAME}_SHARED_LIBS    "Build ${PROJECT_NAME} as a shared lib"  OFF)
+option(${PROJECT_NAME}_BUILD_EXAMPLES "Build ${PROJECT_NAME} examples"         ON)
 
-set_if_undefined(${PROJECT_NAME}_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING
-    "Install path for ${PROJECT_NAME} package-related CMake files")
+set_if_undefined(${PROJECT_NAME}_INSTALL_CMAKEDIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    CACHE STRING "Install destination for ${PROJECT_NAME} CMake package files")
 
 if(DEFINED ${PROJECT_NAME}_SHARED_LIBS)
     set(BUILD_SHARED_LIBS ${${PROJECT_NAME}_SHARED_LIBS})
@@ -43,88 +34,19 @@ endif()
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+        STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set_if_undefined(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set_if_undefined(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+message(STATUS "[${PROJECT_NAME}] Version:      ${PROJECT_VERSION}")
+message(STATUS "[${PROJECT_NAME}] Build type:   ${CMAKE_BUILD_TYPE}")
+message(STATUS "[${PROJECT_NAME}] Shared libs:  ${BUILD_SHARED_LIBS}")
+message(STATUS "[${PROJECT_NAME}] Top-level:    ${is_top_level}")
 
-include(CheckCXXCompilerFlag)
-
-if(MSVC)
-    CHECK_CXX_COMPILER_FLAG("/std:c++20" COMPILER_SUPPORTS_CXX20)
-    CHECK_CXX_COMPILER_FLAG("/std:c++latest" COMPILER_SUPPORTS_CXXLATEST)
-    if(COMPILER_SUPPORTS_CXX20)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20")
-    elseif(COMPILER_SUPPORTS_CXXLATEST)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
-    else()
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++20 support.")
-    endif()
-else()
-    CHECK_CXX_COMPILER_FLAG("-std=c++20" COMPILER_SUPPORTS_CXX20)
-    if(COMPILER_SUPPORTS_CXX20)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
-    else()
-        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++20 support. Please use a different C++ compiler.")
-    endif()
-endif()
-
-message(STATUS "[INFO]: CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}")
-message(STATUS "[INFO]: CMAKE_CONFIGURATION_TYPES ${CMAKE_CONFIGURATION_TYPES}")
-
-add_subdirectory(include)
+# --------------------------------------------------------------------------- #
+# Subdirectories
+# --------------------------------------------------------------------------- #
 add_subdirectory(src)
-
-include(GenerateExportHeader)
-set(export_file_name "export_shared.h")
-
-if(NOT BUILD_SHARED_LIBS)
-    set(export_file_name "export_static.h")
-endif()
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/export.h.in "${CMAKE_CURRENT_BINARY_DIR}/include/public/include/${PROJECT_NAME}/export.h")
-generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/public/include/${PROJECT_NAME}/${export_file_name})
-
-if(WIN32)
-    set(DLL_VER_VENDOR "SharedMath Developer")
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cmake/version_utils.cmake)
-        include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version_utils.cmake)
-        make_dll_version(${DLL_VER_VENDOR})
-        set(RESOURCES ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    endif()
-endif()
-
-if(WIN32)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC WIN32)
-endif()
-
-target_compile_definitions(${PROJECT_NAME} PUBLIC "$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${PROJECT_NAME_UPPER}_STATIC_DEFINE>")
-
-add_definitions(-D_USE_MATH_DEFINES)
-
-if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /EHsc)
-endif()
-
-if(UNIX)
-    set(LIBS ${LIBS} ${CMAKE_DL_LIBS})
-    message("CMAKE_DL_LIBS: ${CMAKE_DL_LIBS}")
-endif(UNIX)
-
-target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS})
-
-set(${PROJECT_NAME}_STATIC_SUFFIX "")
-if(NOT BUILD_SHARED_LIBS)
-    set(${PROJECT_NAME}_STATIC_SUFFIX "_static")
-
-    if(CMAKE_VERSION VERSION_GREATER 2.8.8)
-        set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
-    elseif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-    endif()
-endif()
 
 if(${PROJECT_NAME}_BUILD_TESTS)
     add_subdirectory(tests)
@@ -134,121 +56,91 @@ if(${PROJECT_NAME}_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+# --------------------------------------------------------------------------- #
+# Install
+# --------------------------------------------------------------------------- #
 if(${PROJECT_NAME}_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
-    string(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "Release" is_release_build)
-    message(STATUS "[INFO]: is_release_build ${is_release_build}")
-
-    include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
-    
-    configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/project-config.cmake.in 
-        ${PROJECT_NAME}-config.cmake
-        INSTALL_DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKEDIR}")
+    include(CMakePackageConfigHelpers)
 
-    write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT  ${PROJECT_NAME}_export
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}   COMPONENT bin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}   COMPONENT bin
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}   COMPONENT bin
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    if(MSVC AND BUILD_SHARED_LIBS)
+        install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}>
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+            COMPONENT   dbg
+            OPTIONAL)
+    endif()
+
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        COMPONENT   devel
+        FILES_MATCHING PATTERN "*.h")
+
+    install(FILES ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME_LOWER}_export.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        COMPONENT   devel)
+
+    install(EXPORT ${PROJECT_NAME}_export
+        FILE        ${PROJECT_NAME}-targets.cmake
+        NAMESPACE   ${PROJECT_NAME}::
+        DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKEDIR}"
+        COMPONENT   devel)
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/project-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+        INSTALL_DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKEDIR}"
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
         COMPATIBILITY SameMajorVersion)
 
-    if(is_release_build)
-        install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}_export
-                RUNTIME COMPONENT bin
-                LIBRARY COMPONENT bin
-                ARCHIVE COMPONENT bin CONFIGURATIONS Release
-                INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+        DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKEDIR}"
+        COMPONENT   devel)
 
-        set(targets_file "${PROJECT_NAME}-shared-targets.cmake")
-
-        if(NOT BUILD_SHARED_LIBS)
-            set(targets_file "${PROJECT_NAME}-static-targets.cmake")
-        endif()
-
-        install(EXPORT ${PROJECT_NAME}_export
-                COMPONENT devel
-                FILE "${targets_file}"
-                DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKEDIR}"
-                NAMESPACE ${PROJECT_NAME}::
-                CONFIGURATIONS Release OPTIONAL)
-
-        install(FILES
-                "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-                "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-                COMPONENT devel
-                DESTINATION "${${PROJECT_NAME}_INSTALL_CMAKEDIR}"
-                CONFIGURATIONS Release OPTIONAL)
-
-    else(is_release_build)
-        install(TARGETS ${PROJECT_NAME}
-                RUNTIME COMPONENT dbg
-                LIBRARY COMPONENT dbg
-                ARCHIVE COMPONENT dbg
-                CONFIGURATIONS Debug RelWithDebInfo)
-
-        if(MSVC)
-            set(pdb_file "")
-            set(pdb_file_destination "")
-
-            if(BUILD_SHARED_LIBS)
-                set(pdb_file "$<TARGET_PDB_FILE:${PROJECT_NAME}>")
-                set(pdb_file_destination "${CMAKE_INSTALL_BINDIR}")
-            else(BUILD_SHARED_LIBS)
-                set(pdb_file "$<TARGET_FILE_DIR:${PROJECT_NAME}>/$<TARGET_FILE_PREFIX:${PROJECT_NAME}>$<TARGET_FILE_BASE_NAME:${PROJECT_NAME}>.pdb")
-                set(pdb_file_destination "${CMAKE_INSTALL_LIBDIR}")
-            endif(BUILD_SHARED_LIBS)
-
-            install(FILES "${pdb_file}"
-                COMPONENT dbg
-                CONFIGURATIONS Debug RelWithDebInfo
-                DESTINATION "${pdb_file_destination}"
-                OPTIONAL)
-        endif(MSVC)
-    endif(is_release_build)
-    
+    # ----------------------------------------------------------------------- #
+    # CPack (top-level only)
+    # ----------------------------------------------------------------------- #
     if(is_top_level)
         set(CPACK_VERBATIM_VARIABLES YES)
-        set(CPACK_SET_DESTDIR TRUE)
-        set(CPACK_PACKAGE_RELOCATABLE ON)
-
-        set(CPACK_PACKAGE_CONTACT "D.Rylov <danila.rylov2005@mail.ru>")
+        set(CPACK_PACKAGE_CONTACT    "D.Rylov <danila.rylov2005@mail.ru>")
+        set(CPACK_PACKAGE_VENDOR     "SharedMath Team")
+        set(CPACK_PACKAGE_NAME       ${PROJECT_NAME})
+        set(CPACK_PACKAGE_VERSION    ${PROJECT_VERSION})
         set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Shared Math Library")
-        set(CPACK_PACKAGE_VENDOR "SharedMath Team")
-
-        set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
-        set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
-
-        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${PROJECT_VERSION}_${CMAKE_SYSTEM_NAME}")
-        set(CPACK_STRIP_FILES is_release_build)
-        set(CPACK_INSTALL_PREFIX "/")
+        set(CPACK_PACKAGE_FILE_NAME
+            "${PROJECT_NAME}_${PROJECT_VERSION}_${CMAKE_SYSTEM_NAME}")
+        set(CPACK_STRIP_FILES ON)
 
         if(UNIX)
             set(CPACK_GENERATOR "TBZ2;DEB")
-            set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS On)
-            set(CPACK_STRIP_FILES ON)
+            set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
             execute_process(
                 COMMAND dpkg --print-architecture
                 OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
                 OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
-            
-            if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
-                set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE arm64)
-            endif()
-            
-            set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}_${CMAKE_SYSTEM_PROCESSOR}${${PROJECT_NAME}_STATIC_SUFFIX}")
+                ERROR_QUIET)
+            set(CPACK_PACKAGE_FILE_NAME
+                "${CPACK_PACKAGE_FILE_NAME}_${CMAKE_SYSTEM_PROCESSOR}")
         else()
             set(CPACK_GENERATOR "ZIP")
-            find_program(NSIS_PROGRAM makensis.exe
-                PATHS
-                "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NSIS;InstallLocation]"
-                "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NSIS;InstallLocation]")
-            
+            find_program(NSIS_PROGRAM makensis.exe)
             if(NSIS_PROGRAM)
-                set(CPACK_SET_DESTDIR FALSE)
-                set(CPACK_GENERATOR "${CPACK_GENERATOR};NSIS")
+                list(APPEND CPACK_GENERATOR "NSIS")
             endif()
-            
-            set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}${${PROJECT_NAME}_STATIC_SUFFIX}")
         endif()
-        
-        message(STATUS "[INFO]: CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_FILE_NAME}")
+
         include(CPack)
-    endif(is_top_level)
+    endif()
 endif()

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -4,21 +4,3 @@ include(CMakeFindDependencyMacro)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 check_required_components("@PROJECT_NAME@")
-
-set(@PROJECT_NAME_UPPER@_FOUND TRUE)
-set(@PROJECT_NAME_UPPER@_VERSION @PROJECT_VERSION@)
-set(@PROJECT_NAME_UPPER@_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
-set(@PROJECT_NAME_UPPER@_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@)
-
-function(@PROJECT_NAME@_setup_target target)
-    if(NOT TARGET ${target})
-        message(FATAL_ERROR "Target ${target} does not exist")
-    endif()
-    
-    target_link_libraries(${target} PRIVATE @PROJECT_NAME@::@PROJECT_NAME@)
-    target_include_directories(${target} PRIVATE "@PACKAGE_INCLUDE_INSTALL_DIR@")
-    
-    if(@PROJECT_NAME@_SHARED_LIBS)
-        target_compile_definitions(${target} PRIVATE @PROJECT_NAME_UPPER@_LIBRARY)
-    endif()
-endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,0 +1,5 @@
+macro(set_if_undefined variable)
+    if(NOT DEFINED ${variable})
+        set(${variable} ${ARGN})
+    endif()
+endmacro()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,2 @@
-
-if(BUILD_EXAMPLES)
-    
-    add_executable(demo_example example.cpp)
-    target_link_libraries(demo_example PRIVATE SharedMath)
-
-
-
-endif()
+add_executable(demo_example example.cpp)
+target_link_libraries(demo_example PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})

--- a/include/LinearAlgebra/LUDecomposition.h
+++ b/include/LinearAlgebra/LUDecomposition.h
@@ -1,9 +1,11 @@
+#pragma once
 #include "DynamicMatrix.h"
+#include <sharedmath_export.h>
 
 namespace SharedMath::LinearAlgebra
 {
 
-    class LUDecomposition
+    class SHAREDMATH_EXPORT LUDecomposition
     {
     private:
         DynamicMatrix L;

--- a/include/LinearAlgebra/MatrixOperationFactory.h
+++ b/include/LinearAlgebra/MatrixOperationFactory.h
@@ -4,6 +4,7 @@
 #include "DefaultBinaryMatrixStrategies.h"
 #include "DefaultUnaryMatrixStrategies.h"
 #include "DefaultScalarMatrixOperations.h"
+#include <sharedmath_export.h>
 #include <memory>
 #include <functional>
 
@@ -19,7 +20,7 @@ namespace SharedMath::LinearAlgebra
         DETERMINANT
     };
 
-    class AbstractMatrixStrategyFactory{
+    class SHAREDMATH_EXPORT AbstractMatrixStrategyFactory{
     public:
         
         using BinaryStrategyCreator = std::function<std::unique_ptr<BinaryMatrixOperationStrategy>()>;
@@ -43,7 +44,7 @@ namespace SharedMath::LinearAlgebra
     };
 
 
-    class MatrixStrategyFactory : public AbstractMatrixStrategyFactory{
+    class SHAREDMATH_EXPORT MatrixStrategyFactory : public AbstractMatrixStrategyFactory{
     public:
         
         MatrixStrategyFactory();    

--- a/include/LinearAlgebra/MatrixOperations.h
+++ b/include/LinearAlgebra/MatrixOperations.h
@@ -2,10 +2,11 @@
 
 #include "MatrixOperationsContext.h"
 #include "MatrixOperationFactory.h"
+#include <sharedmath_export.h>
 
 namespace SharedMath::LinearAlgebra
 {
-    class MatrixOperations{
+    class SHAREDMATH_EXPORT MatrixOperations{
     public:
         using MatrixPtr = std::shared_ptr<AbstractMatrix>;
 

--- a/include/LinearAlgebra/MatrixView.h
+++ b/include/LinearAlgebra/MatrixView.h
@@ -1,12 +1,13 @@
 #pragma once
 #include "Matrix.h"
+#include <sharedmath_export.h>
 #include <memory>
 
 namespace SharedMath
 {
     namespace LinearAlgebra
     {
-        class MatrixView {
+        class SHAREDMATH_EXPORT MatrixView {
         public:
             MatrixView() = default;
 
@@ -24,7 +25,7 @@ namespace SharedMath
             size_t cols() const;
 
             double get(size_t row, size_t col) const;
-            void set(size_t row, size_t col, double val); \
+            void set(size_t row, size_t col, double val);
 
             double operator()(size_t row, size_t col) const;
             double& operator()(size_t row, size_t col);

--- a/include/functions/GammaFunc.h
+++ b/include/functions/GammaFunc.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "../constans.h"
+#include <sharedmath_export.h>
 #include <complex>
 
 namespace SharedMath
 {
     namespace Functions
     {
-        class GammaFunction{
+        class SHAREDMATH_EXPORT GammaFunction{
             public:
                 static double value(double x);
                 static std::complex<double> value(const std::complex<double>& z);

--- a/include/geometry/Planimetry/Parallelogram.h
+++ b/include/geometry/Planimetry/Parallelogram.h
@@ -3,6 +3,7 @@
 #include "Polygon.h"
 #include "../Vectors.h"
 #include "../../constans.h"
+#include <sharedmath_export.h>
 #include <math.h>
 #include <algorithm>
 #include <stdexcept>
@@ -12,7 +13,7 @@ namespace SharedMath
 {
     namespace Geometry
     {
-        class Parallelogram : public Polygon<4>{
+        class SHAREDMATH_EXPORT Parallelogram : public Polygon<4>{
         public:
             Parallelogram() = default;
 

--- a/include/geometry/Planimetry/Rectangle.h
+++ b/include/geometry/Planimetry/Rectangle.h
@@ -5,7 +5,7 @@ namespace SharedMath
 {
     namespace Geometry
     {
-        class Rectangle : public Parallelogram {
+        class SHAREDMATH_EXPORT Rectangle : public Parallelogram {
         public:
             Rectangle() = default;
 

--- a/include/geometry/Planimetry/Triangle.h
+++ b/include/geometry/Planimetry/Triangle.h
@@ -2,13 +2,14 @@
 
 #include "Polygon.h"
 #include "../Vectors.h"
+#include <sharedmath_export.h>
 #include <algorithm>
 
 namespace SharedMath
 {
     namespace Geometry
     {
-        class Triangle : public Polygon<3>{
+        class SHAREDMATH_EXPORT Triangle : public Polygon<3>{
         public:
             Triangle() = default;
             Triangle(const Triangle&) = default;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,25 +1,56 @@
+include(GNUInstallDirs)
+include(GenerateExportHeader)
 
-
-add_library(
-    SharedMath
-    #Add source Files 
+add_library(${PROJECT_NAME}
     geometry/Parallelogram.cpp
     geometry/Rectangle.cpp
     geometry/Triangle.cpp
-
     LinearAlgebra/MatrixView.cpp
     LinearAlgebra/MatrixOperationFactory.cpp
     LinearAlgebra/MatrixOperations.cpp
     LinearAlgebra/LUDecomposition.cpp
-
     functions/GammaFunc.cpp
-
     SharedMath.cpp
 )
 
-target_include_directories(SharedMath PUBLIC 
-    ${CMAKE_CURRENT_SOURCE_DIR}/../include
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+# Generate the export header (SHAREDMATH_EXPORT macro)
+generate_export_header(${PROJECT_NAME}
+    EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME_LOWER}_export.h)
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-install(TARGETS SharedMath DESTINATION SharedMathLib)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/SharedMath DESTINATION include)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    VERSION                   ${PROJECT_VERSION}
+    SOVERSION                 ${PROJECT_VERSION_MAJOR}
+    POSITION_INDEPENDENT_CODE ON
+    CXX_VISIBILITY_PRESET     hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+
+target_compile_definitions(${PROJECT_NAME}
+    PUBLIC
+        # consumers of the static lib get SHAREDMATH_STATIC_DEFINE
+        $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${PROJECT_NAME_UPPER}_STATIC_DEFINE>
+        $<$<BOOL:${WIN32}>:WIN32 _USE_MATH_DEFINES>
+    PRIVATE
+        $<$<NOT:$<BOOL:${WIN32}>>:_USE_MATH_DEFINES>
+)
+
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /EHsc /W3)
+else()
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(UNIX)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,9 @@
-cmake_minimum_required(VERSION 3.10)
-project(SharedMathTests)
-
 find_package(GTest REQUIRED)
 include(GoogleTest)
 
-link_directories(${CMAKE_SOURCE_DIR}/../build)
-
-add_executable(SharedMathTests
+add_executable(${PROJECT_NAME}Tests
     main.cpp
+    test_binary_tree.cpp
     # test_geometry_lines.cpp
     # test_geometry_polygon.cpp
     # test_geometry_rect.cpp
@@ -16,16 +12,19 @@ add_executable(SharedMathTests
     # test_linAl_matrix.cpp
     # test_linAl_matrixOperations.cpp
     # test_functions.cpp
-    test_binary_tree.cpp
-
 )
-target_link_libraries(SharedMathTests PRIVATE GTest::GTest GTest::Main SharedMath)
-target_include_directories(SharedMathTests PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
+target_link_libraries(${PROJECT_NAME}Tests
+    PRIVATE
+        ${PROJECT_NAME}::${PROJECT_NAME}
+        GTest::GTest
+        GTest::Main
+)
 
 enable_testing()
-gtest_discover_tests(SharedMathTests)
+gtest_discover_tests(${PROJECT_NAME}Tests)
+
 add_custom_command(
-    TARGET SharedMathTests POST_BUILD
+    TARGET ${PROJECT_NAME}Tests POST_BUILD
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    COMMENT "Running tests..."
-)
+    COMMENT "Running ${PROJECT_NAME} tests...")


### PR DESCRIPTION
CMake infrastructure:
- Create cmake/utils.cmake with set_if_undefined macro (was used but missing — blocked configure)
- Rewrite root CMakeLists.txt: remove empty include/ subdirectory, drop raw CXX_FLAGS string manipulation in favour of target_compile_features(cxx_std_20), unify install targets file to SharedMath-targets.cmake (was -shared/-static variants that didn't match project-config.cmake.in)
- Rewrite src/CMakeLists.txt: use PROJECT_NAME throughout, add ::SharedMath ALIAS target, call generate_export_header, set VERSION/SOVERSION/POSITION_INDEPENDENT_CODE/visibility preset, move all target-specific definitions and compiler options here
- Rewrite tests/CMakeLists.txt: remove standalone cmake_minimum_required/project, remove link_directories hack, link via SharedMath::SharedMath target alias
- Rewrite examples/CMakeLists.txt: use correct option variable and ALIAS target
- Fix cmake/project-config.cmake.in: include SharedMath-targets.cmake (unified name)
- Remove empty include/CMakeLists.txt
- Fix .gitignore: *.cmake was too broad and blocked cmake source modules; add !cmake/*.cmake

Export macros (required for CXX_VISIBILITY_PRESET hidden on all platforms):
- generate_export_header produces sharedmath_export.h with SHAREDMATH_EXPORT macro
- Add SHAREDMATH_EXPORT to every non-template class that has a .cpp implementation: Parallelogram, Rectangle, Triangle, GammaFunction, LUDecomposition, AbstractMatrixStrategyFactory, MatrixStrategyFactory, MatrixOperations, MatrixView
- Also fix LUDecomposition.h missing #pragma once and MatrixView.h spurious backslash

Usage:
  cmake -B build -DSharedMath_SHARED_LIBS=ON   # shared (.so / .dll)
  cmake -B build                               # static (.a / .lib, default)