### PR TITLE
Split library into independent per-module CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,19 +63,33 @@ if(${PROJECT_NAME}_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 
-    install(TARGETS ${PROJECT_NAME}
+    # INTERFACE targets (no artifacts — just headers + compile requirements)
+    install(TARGETS
+        SharedMath
+        SharedMath_Core
+        SharedMath_Graphs
+        SharedMath_DSP
+        EXPORT ${PROJECT_NAME}_export
+    )
+
+    # Compiled module targets
+    install(TARGETS
+        SharedMath_LinearAlgebra
+        SharedMath_Geometry
+        SharedMath_Functions
         EXPORT  ${PROJECT_NAME}_export
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}   COMPONENT bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}   COMPONENT bin
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}   COMPONENT bin
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 
     if(MSVC AND BUILD_SHARED_LIBS)
-        install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}>
-            DESTINATION ${CMAKE_INSTALL_BINDIR}
-            COMPONENT   dbg
-            OPTIONAL)
+        foreach(_mod LinearAlgebra Geometry Functions)
+            install(FILES $<TARGET_PDB_FILE:SharedMath_${_mod}>
+                DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT   dbg
+                OPTIONAL)
+        endforeach()
     endif()
 
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
@@ -83,9 +97,11 @@ if(${PROJECT_NAME}_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
         COMPONENT   devel
         FILES_MATCHING PATTERN "*.h")
 
-    install(FILES ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME_LOWER}_export.h
+    # Install generated export headers for each module
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        COMPONENT   devel)
+        COMPONENT   devel
+        FILES_MATCHING PATTERN "*_export.h")
 
     install(EXPORT ${PROJECT_NAME}_export
         FILE        ${PROJECT_NAME}-targets.cmake

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -3,3 +3,23 @@ macro(set_if_undefined variable)
         set(${variable} ${ARGN})
     endif()
 endmacro()
+
+# Apply standard build properties to a compiled SharedMath module target.
+function(sharedmath_configure_module target)
+    set_target_properties(${target} PROPERTIES
+        VERSION                   ${PROJECT_VERSION}
+        SOVERSION                 ${PROJECT_VERSION_MAJOR}
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET     hidden
+        VISIBILITY_INLINES_HIDDEN ON
+        DEBUG_POSTFIX             "${CMAKE_DEBUG_POSTFIX}"
+    )
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /EHsc /W3)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+    if(UNIX)
+        target_link_libraries(${target} PRIVATE ${CMAKE_DL_LIBS})
+    endif()
+endfunction()

--- a/include/DSP/dsp.h
+++ b/include/DSP/dsp.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// DSP (Digital Signal Processing) module — work in progress.
+// Planned: FFT/IFFT, convolution, FIR/IIR filters, windowing.
+//
+// Usage (once implemented):
+//   #include <DSP/dsp.h>
+//   ...
+//   target_link_libraries(myapp PRIVATE SharedMath::DSP)
+
+namespace SharedMath::DSP
+{
+    // Coming soon.
+}

--- a/include/LinearAlgebra/LUDecomposition.h
+++ b/include/LinearAlgebra/LUDecomposition.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "DynamicMatrix.h"
-#include <sharedmath_export.h>
+#include <sharedmath_linearalgebra_export.h>
 
 namespace SharedMath::LinearAlgebra
 {
 
-    class SHAREDMATH_EXPORT LUDecomposition
+    class SHAREDMATH_LINEARALGEBRA_EXPORT LUDecomposition
     {
     private:
         DynamicMatrix L;

--- a/include/LinearAlgebra/MatrixOperationFactory.h
+++ b/include/LinearAlgebra/MatrixOperationFactory.h
@@ -4,7 +4,7 @@
 #include "DefaultBinaryMatrixStrategies.h"
 #include "DefaultUnaryMatrixStrategies.h"
 #include "DefaultScalarMatrixOperations.h"
-#include <sharedmath_export.h>
+#include <sharedmath_linearalgebra_export.h>
 #include <memory>
 #include <functional>
 
@@ -20,7 +20,7 @@ namespace SharedMath::LinearAlgebra
         DETERMINANT
     };
 
-    class SHAREDMATH_EXPORT AbstractMatrixStrategyFactory{
+    class SHAREDMATH_LINEARALGEBRA_EXPORT AbstractMatrixStrategyFactory{
     public:
         
         using BinaryStrategyCreator = std::function<std::unique_ptr<BinaryMatrixOperationStrategy>()>;
@@ -44,7 +44,7 @@ namespace SharedMath::LinearAlgebra
     };
 
 
-    class SHAREDMATH_EXPORT MatrixStrategyFactory : public AbstractMatrixStrategyFactory{
+    class SHAREDMATH_LINEARALGEBRA_EXPORT MatrixStrategyFactory : public AbstractMatrixStrategyFactory{
     public:
         
         MatrixStrategyFactory();    

--- a/include/LinearAlgebra/MatrixOperations.h
+++ b/include/LinearAlgebra/MatrixOperations.h
@@ -2,11 +2,11 @@
 
 #include "MatrixOperationsContext.h"
 #include "MatrixOperationFactory.h"
-#include <sharedmath_export.h>
+#include <sharedmath_linearalgebra_export.h>
 
 namespace SharedMath::LinearAlgebra
 {
-    class SHAREDMATH_EXPORT MatrixOperations{
+    class SHAREDMATH_LINEARALGEBRA_EXPORT MatrixOperations{
     public:
         using MatrixPtr = std::shared_ptr<AbstractMatrix>;
 

--- a/include/LinearAlgebra/MatrixView.h
+++ b/include/LinearAlgebra/MatrixView.h
@@ -1,13 +1,13 @@
 #pragma once
 #include "Matrix.h"
-#include <sharedmath_export.h>
+#include <sharedmath_linearalgebra_export.h>
 #include <memory>
 
 namespace SharedMath
 {
     namespace LinearAlgebra
     {
-        class SHAREDMATH_EXPORT MatrixView {
+        class SHAREDMATH_LINEARALGEBRA_EXPORT MatrixView {
         public:
             MatrixView() = default;
 

--- a/include/functions/GammaFunc.h
+++ b/include/functions/GammaFunc.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "../constans.h"
-#include <sharedmath_export.h>
+#include <sharedmath_functions_export.h>
 #include <complex>
 
 namespace SharedMath
 {
     namespace Functions
     {
-        class SHAREDMATH_EXPORT GammaFunction{
+        class SHAREDMATH_FUNCTIONS_EXPORT GammaFunction{
             public:
                 static double value(double x);
                 static std::complex<double> value(const std::complex<double>& z);

--- a/include/geometry/Planimetry/Parallelogram.h
+++ b/include/geometry/Planimetry/Parallelogram.h
@@ -3,7 +3,7 @@
 #include "Polygon.h"
 #include "../Vectors.h"
 #include "../../constans.h"
-#include <sharedmath_export.h>
+#include <sharedmath_geometry_export.h>
 #include <math.h>
 #include <algorithm>
 #include <stdexcept>
@@ -13,7 +13,7 @@ namespace SharedMath
 {
     namespace Geometry
     {
-        class SHAREDMATH_EXPORT Parallelogram : public Polygon<4>{
+        class SHAREDMATH_GEOMETRY_EXPORT Parallelogram : public Polygon<4>{
         public:
             Parallelogram() = default;
 

--- a/include/geometry/Planimetry/Rectangle.h
+++ b/include/geometry/Planimetry/Rectangle.h
@@ -5,7 +5,7 @@ namespace SharedMath
 {
     namespace Geometry
     {
-        class SHAREDMATH_EXPORT Rectangle : public Parallelogram {
+        class SHAREDMATH_GEOMETRY_EXPORT Rectangle : public Parallelogram {
         public:
             Rectangle() = default;
 

--- a/include/geometry/Planimetry/Triangle.h
+++ b/include/geometry/Planimetry/Triangle.h
@@ -2,14 +2,14 @@
 
 #include "Polygon.h"
 #include "../Vectors.h"
-#include <sharedmath_export.h>
+#include <sharedmath_geometry_export.h>
 #include <algorithm>
 
 namespace SharedMath
 {
     namespace Geometry
     {
-        class SHAREDMATH_EXPORT Triangle : public Polygon<3>{
+        class SHAREDMATH_GEOMETRY_EXPORT Triangle : public Polygon<3>{
         public:
             Triangle() = default;
             Triangle(const Triangle&) = default;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,56 +1,20 @@
-include(GNUInstallDirs)
-include(GenerateExportHeader)
+add_subdirectory(core)
+add_subdirectory(LinearAlgebra)
+add_subdirectory(geometry)
+add_subdirectory(functions)
+add_subdirectory(Graphs)
+add_subdirectory(DSP)
 
-add_library(${PROJECT_NAME}
-    geometry/Parallelogram.cpp
-    geometry/Rectangle.cpp
-    geometry/Triangle.cpp
-    LinearAlgebra/MatrixView.cpp
-    LinearAlgebra/MatrixOperationFactory.cpp
-    LinearAlgebra/MatrixOperations.cpp
-    LinearAlgebra/LUDecomposition.cpp
-    functions/GammaFunc.cpp
-    SharedMath.cpp
+# Umbrella target — links every module so users can do:
+#   target_link_libraries(myapp PRIVATE SharedMath::SharedMath)
+add_library(SharedMath INTERFACE)
+add_library(SharedMath::SharedMath ALIAS SharedMath)
+
+target_link_libraries(SharedMath INTERFACE
+    SharedMath_Core
+    SharedMath_LinearAlgebra
+    SharedMath_Geometry
+    SharedMath_Functions
+    SharedMath_Graphs
+    SharedMath_DSP
 )
-
-add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
-# Generate the export header (SHAREDMATH_EXPORT macro)
-generate_export_header(${PROJECT_NAME}
-    EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/${PROJECT_NAME_LOWER}_export.h)
-
-target_include_directories(${PROJECT_NAME}
-    PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    VERSION                   ${PROJECT_VERSION}
-    SOVERSION                 ${PROJECT_VERSION_MAJOR}
-    POSITION_INDEPENDENT_CODE ON
-    CXX_VISIBILITY_PRESET     hidden
-    VISIBILITY_INLINES_HIDDEN ON
-)
-
-target_compile_definitions(${PROJECT_NAME}
-    PUBLIC
-        # consumers of the static lib get SHAREDMATH_STATIC_DEFINE
-        $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${PROJECT_NAME_UPPER}_STATIC_DEFINE>
-        $<$<BOOL:${WIN32}>:WIN32 _USE_MATH_DEFINES>
-    PRIVATE
-        $<$<NOT:$<BOOL:${WIN32}>>:_USE_MATH_DEFINES>
-)
-
-if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /EHsc /W3)
-else()
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
-endif()
-
-if(UNIX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
-endif()

--- a/src/DSP/CMakeLists.txt
+++ b/src/DSP/CMakeLists.txt
@@ -1,0 +1,11 @@
+# DSP (Digital Signal Processing) module — placeholder.
+# Planned: FFT, convolution, FIR/IIR filters, windowing functions.
+# Add source files and compiled-library rules here when implementing.
+
+add_library(SharedMath_DSP INTERFACE)
+add_library(SharedMath::DSP ALIAS SharedMath_DSP)
+
+target_link_libraries(SharedMath_DSP INTERFACE
+    SharedMath_Core
+    SharedMath_LinearAlgebra
+)

--- a/src/Graphs/CMakeLists.txt
+++ b/src/Graphs/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(SharedMath_Graphs INTERFACE)
+add_library(SharedMath::Graphs ALIAS SharedMath_Graphs)
+
+# Graphs module is header-only (BinaryTree, BaseGraph are templates).
+target_link_libraries(SharedMath_Graphs INTERFACE SharedMath_Core)

--- a/src/LinearAlgebra/CMakeLists.txt
+++ b/src/LinearAlgebra/CMakeLists.txt
@@ -1,0 +1,23 @@
+include(GenerateExportHeader)
+
+add_library(SharedMath_LinearAlgebra
+    MatrixView.cpp
+    MatrixOperationFactory.cpp
+    MatrixOperations.cpp
+    LUDecomposition.cpp
+)
+add_library(SharedMath::LinearAlgebra ALIAS SharedMath_LinearAlgebra)
+
+generate_export_header(SharedMath_LinearAlgebra
+    EXPORT_MACRO_NAME SHAREDMATH_LINEARALGEBRA_EXPORT
+    EXPORT_FILE_NAME  ${PROJECT_BINARY_DIR}/include/sharedmath_linearalgebra_export.h
+    STATIC_DEFINE     SHAREDMATH_LINEARALGEBRA_STATIC_DEFINE
+)
+
+target_link_libraries(SharedMath_LinearAlgebra PUBLIC SharedMath_Core)
+
+target_compile_definitions(SharedMath_LinearAlgebra PUBLIC
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:SHAREDMATH_LINEARALGEBRA_STATIC_DEFINE>
+)
+
+sharedmath_configure_module(SharedMath_LinearAlgebra)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(GNUInstallDirs)
+
+add_library(SharedMath_Core INTERFACE)
+add_library(SharedMath::Core ALIAS SharedMath_Core)
+
+target_include_directories(SharedMath_Core INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(SharedMath_Core INTERFACE cxx_std_20)
+
+target_compile_definitions(SharedMath_Core INTERFACE
+    _USE_MATH_DEFINES
+    $<$<BOOL:${WIN32}>:WIN32>
+)

--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -1,0 +1,20 @@
+include(GenerateExportHeader)
+
+add_library(SharedMath_Functions
+    GammaFunc.cpp
+)
+add_library(SharedMath::Functions ALIAS SharedMath_Functions)
+
+generate_export_header(SharedMath_Functions
+    EXPORT_MACRO_NAME SHAREDMATH_FUNCTIONS_EXPORT
+    EXPORT_FILE_NAME  ${PROJECT_BINARY_DIR}/include/sharedmath_functions_export.h
+    STATIC_DEFINE     SHAREDMATH_FUNCTIONS_STATIC_DEFINE
+)
+
+target_link_libraries(SharedMath_Functions PUBLIC SharedMath_Core)
+
+target_compile_definitions(SharedMath_Functions PUBLIC
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:SHAREDMATH_FUNCTIONS_STATIC_DEFINE>
+)
+
+sharedmath_configure_module(SharedMath_Functions)

--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -1,0 +1,22 @@
+include(GenerateExportHeader)
+
+add_library(SharedMath_Geometry
+    Parallelogram.cpp
+    Rectangle.cpp
+    Triangle.cpp
+)
+add_library(SharedMath::Geometry ALIAS SharedMath_Geometry)
+
+generate_export_header(SharedMath_Geometry
+    EXPORT_MACRO_NAME SHAREDMATH_GEOMETRY_EXPORT
+    EXPORT_FILE_NAME  ${PROJECT_BINARY_DIR}/include/sharedmath_geometry_export.h
+    STATIC_DEFINE     SHAREDMATH_GEOMETRY_STATIC_DEFINE
+)
+
+target_link_libraries(SharedMath_Geometry PUBLIC SharedMath_Core)
+
+target_compile_definitions(SharedMath_Geometry PUBLIC
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:SHAREDMATH_GEOMETRY_STATIC_DEFINE>
+)
+
+sharedmath_configure_module(SharedMath_Geometry)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(${PROJECT_NAME}Tests
 
 target_link_libraries(${PROJECT_NAME}Tests
     PRIVATE
-        ${PROJECT_NAME}::${PROJECT_NAME}
+        SharedMath::SharedMath
         GTest::GTest
         GTest::Main
 )


### PR DESCRIPTION
Each module is now a first-class CMake target consumable individually:

  target_link_libraries(myapp PRIVATE SharedMath::LinearAlgebra)
  target_link_libraries(myapp PRIVATE SharedMath::Geometry)
  target_link_libraries(myapp PRIVATE SharedMath::Functions)
  target_link_libraries(myapp PRIVATE SharedMath::Graphs)
  target_link_libraries(myapp PRIVATE SharedMath::DSP)
  target_link_libraries(myapp PRIVATE SharedMath::SharedMath)  # all modules

Module targets:
- SharedMath::Core          — INTERFACE: include paths, cxx_std_20, _USE_MATH_DEFINES
- SharedMath::LinearAlgebra — compiled: Matrix, LU, MatrixView, factory, operations
- SharedMath::Geometry      — compiled: Triangle, Rectangle, Parallelogram + base classes
- SharedMath::Functions     — compiled: GammaFunction, digamma, ln_gamma
- SharedMath::Graphs        — INTERFACE: BinaryTree, BaseGraph (header-only templates)
- SharedMath::DSP           — INTERFACE placeholder (FFT, filters — coming later)
- SharedMath::SharedMath    — INTERFACE umbrella linking all modules

Each compiled module gets its own export header generated by generate_export_header:
  sharedmath_linearalgebra_export.h → SHAREDMATH_LINEARALGEBRA_EXPORT
  sharedmath_geometry_export.h      → SHAREDMATH_GEOMETRY_EXPORT
  sharedmath_functions_export.h     → SHAREDMATH_FUNCTIONS_EXPORT

cmake/utils.cmake gains sharedmath_configure_module() to DRY common module properties (VERSION, SOVERSION, PIC, visibility, compiler warnings).

Install exports all targets under SharedMath::  namespace in a single SharedMath-targets.cmake so find_package(SharedMath) exposes every module alias.