### PR TITLE
fix: resolve 3 failing tests — eig NaN, SVD identity, det singularity

### DIFF
--- a/LinearAlgebra/include/LinearAlgebra/DefaultScalarMatrixOperations.h
+++ b/LinearAlgebra/include/LinearAlgebra/DefaultScalarMatrixOperations.h
@@ -19,11 +19,12 @@ public:
         LUDecomposition lu(M);
         try {
             lu.MakeDecomposition();
-            return lu.Determinant();
-        } catch (const std::exception& ex) {
-            throw std::runtime_error(
-                std::string("MatrixDeterminantStrategy: ") + ex.what());
+        } catch (const std::runtime_error&) {
+            // MakeDecomposition throws when the matrix is singular.
+            // A singular matrix has determinant 0 — return it, don't rethrow.
+            return 0.0;
         }
+        return lu.Determinant();
     }
 
     bool isSupported(const AbstractMatrix& A) const override {

--- a/LinearAlgebra/src/MatrixFunctions.cpp
+++ b/LinearAlgebra/src/MatrixFunctions.cpp
@@ -303,35 +303,45 @@ eig(const AbstractMatrix& A, size_t max_iter)
     DynamicMatrix V = eye(n);
 
     for (size_t iter = 0; iter < max_iter; ++iter) {
-        // Wilkinson shift using the bottom-right 2×2 submatrix
-        double shift = 0.0;
-        if (n >= 2) {
-            double d  = (Ak.get(n-2, n-2) - Ak.get(n-1, n-1)) / 2.0;
-            double b  = Ak.get(n-1, n-2);
-            double sq = std::sqrt(d * d + b * b);
-            shift = Ak.get(n-1, n-1) - (b * b) / (d + (d >= 0 ? sq : -sq));
+        // ① Check convergence BEFORE touching the matrix.
+        //   This avoids computing the Wilkinson shift when Ak is already
+        //   diagonal (e.g. identity), which would produce 0/0 = NaN.
+        {
+            double off = 0.0;
+            for (size_t i = 0; i < n; ++i)
+                for (size_t j = 0; j < n; ++j)
+                    if (i != j) off += Ak(i, j) * Ak(i, j);
+            if (std::sqrt(off) < 1e-10 * static_cast<double>(n)) break;
         }
 
-        // A_shifted = Ak - shift * I
+        // ② Wilkinson shift from the bottom-right 2×2 submatrix.
+        //    Guard: when the sub-diagonal entry b ≈ 0 the last eigenvalue has
+        //    already separated; use Ak(n-1,n-1) as shift to avoid 0/0 = NaN.
+        double shift = 0.0;
+        if (n >= 2) {
+            double b = Ak(n-1, n-2);
+            if (std::abs(b) < 1e-14) {
+                shift = Ak(n-1, n-1);
+            } else {
+                double d  = (Ak(n-2, n-2) - Ak(n-1, n-1)) / 2.0;
+                double sq = std::sqrt(d * d + b * b);
+                shift = Ak(n-1, n-1) - (b * b) / (d + (d >= 0.0 ? sq : -sq));
+            }
+        }
+
+        // ③ A_shifted = Ak − shift·I
         for (size_t i = 0; i < n; ++i)
-            Ak.set(i, i, Ak.get(i, i) - shift);
+            Ak(i, i) -= shift;
 
         auto [Q, R] = qr(Ak);
 
-        // Ak = R * Q + shift * I
+        // ④ Ak = R·Q + shift·I
         Ak = R * Q;
         for (size_t i = 0; i < n; ++i)
-            Ak.set(i, i, Ak.get(i, i) + shift);
+            Ak(i, i) += shift;
 
-        // Accumulate eigenvectors: V = V * Q
+        // ⑤ Accumulate eigenvectors: V = V·Q
         V = V * Q;
-
-        // Convergence: off-diagonal Frobenius norm
-        double off = 0.0;
-        for (size_t i = 0; i < n; ++i)
-            for (size_t j = 0; j < n; ++j)
-                if (i != j) off += Ak.get(i, j) * Ak.get(i, j);
-        if (std::sqrt(off) < 1e-10 * n) break;
     }
 
     // Extract and sort eigenvalues descending


### PR DESCRIPTION
Eigenvalues.Identity / SVD.SquareReconstructionIdentity
  Root cause: Wilkinson shift formula computed 0/0 = NaN when the input
  matrix was already diagonal (all off-diagonals = 0).
    shift = Ak(n-1,n-1) - b² / (d ± √(d²+b²))
  With b = 0 and d = 0 this gives 0/0 = NaN, which corrupted Ak and
  propagated into all subsequent iterations.

  Two-part fix in eig():
  1. Move convergence check to the TOP of the iteration loop, before the shift is even computed. If off-diagonal Frobenius norm < ε·n the loop breaks immediately (catches already-diagonal inputs on iter 0).
  2. Guard the Wilkinson formula: when |b| < 1e-14 (last eigenvalue already isolated) use shift = Ak(n-1,n-1) directly, avoiding the division by zero entirely.

DeterminantTest.ZeroDeterminant
  Root cause: MatrixDeterminantStrategy re-threw the exception raised by
  LUDecomposition::MakeDecomposition() for singular matrices, instead of
  returning 0.

  Fix: catch std::runtime_error from MakeDecomposition() and return 0.0.
  A singular matrix always has det = 0; the exception is an implementation
  detail of the LU decomposer, not an API error.